### PR TITLE
Allow to specify date in search page URL

### DIFF
--- a/pydailystrips.py
+++ b/pydailystrips.py
@@ -366,6 +366,8 @@ class Strip(object):
         if useragent:
             headers['User-Agent'] = useragent
 
+        self.searchpage = datetime.date.today().strftime(self.searchpage)
+
         if verbose:
             print('------')
             print('Fetching HTML page for %s (%s)' % (self.name, self.strip_id))

--- a/strips.def
+++ b/strips.def
@@ -232,6 +232,14 @@ strip foxtrot
     searchpattern <meta property="og:image" content="(?P<result>https?://(www\.)?foxtrot\.com/wp-content/uploads/\d+/\d+/.*\.(png|gif|jpg))" />
 end
 
+strip garfield
+    name Garfield
+    artist Jim Davis
+    homepage https://www.gocomics.com/garfield/
+    searchpage https://www.gocomics.com/garfield/%Y/%m/%d
+    searchpattern "url\\*":\\*"(?P<result>https://featureassets.gocomics.com/.*?)\\*"
+end
+
 strip getfuzzy
     name Get Fuzzy
     artist Darby Conley


### PR DESCRIPTION
Run strftime on the search page URL before retrieving. This seems to be necessary for some gocomics, as otherwise an empty page is returned. Added Garfield strip definition that uses this as an example.